### PR TITLE
removing telegram group invite link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,6 @@ This repo contains the following details,
 * Localize Rust resources
 
 ## Community Channels: 
-* [Telegram Group Link](https://t.me/joinchat/AAAAAEFQaXicCPeaeVIm_Q)
 * [Rust India Slack Channel](https://rustindia.slack.com) 
   - Get your Slack invitation [here](http://rustindia.herokuapp.com/) 
 


### PR DESCRIPTION
removed telegram group invite link to control Spam